### PR TITLE
Security fix for the nginx config

### DIFF
--- a/webservers/nginx/index.md
+++ b/webservers/nginx/index.md
@@ -10,7 +10,7 @@ Considerations:
 - PHP-FPM is listen on Unix socket on `unix:/run/php/php-fpm.sock`.
 
 ## HTTP set up
-In order to set up a new server block for Bludit, generate a new file with the configuration in `/etc/nginx/conf.d/bludit.conf`, this directory could be different in other distributions of GNU/Linux, for example, in Ubuntu could be `/etc/nginx/sites-enabled/bludit.conf`.
+In order to set up a new server block for Bludit, generate a new file with the configuration in `/etc/nginx/conf.d/bludit.conf`, this directory could be different in other distributions of GNU/Linux, for example, in Ubuntu could be `/etc/nginx/sites-enabled/bludit.conf`. For security reasons dont forget to forbid the access to the folder `/bl-kernel` and the folders `/bl-content/databases`, `/bl-content/pages` and `/bl-content/temp`. Otherwise its possible that users have dirrect access to some files inside these places. 
 
 ```
 server {
@@ -36,6 +36,11 @@ server {
 	location / {
 		try_files $uri $uri/ /index.php?$args;
 	}
+
+	location ^~ /bl-content/tmp/ { deny all; } 
+	location ^~ /bl-content/pages/ { deny all; } 
+	location ^~ /bl-content/databases/ { deny all; } 
+	location ^~ /bl-kernel/ { deny all; } 
 }
 ```
 
@@ -83,6 +88,11 @@ server {
 	location / {
 		try_files $uri $uri/ /index.php?$args;
 	}
+
+	location ^~ /bl-content/tmp/ { deny all; } 
+	location ^~ /bl-content/pages/ { deny all; } 
+	location ^~ /bl-content/databases/ { deny all; } 
+	location ^~ /bl-kernel/ { deny all; } 
 }
 
 # Redirect from HTTP to HTTPS


### PR DESCRIPTION
Without blocking the access to the folders `/bl-kernel`, `/bl-content/databases`, `/bl-content/pages` and `/bl-content/temp` users can have direct access to, for example, the post and pages. I know that all php files are protected with the `<?php defined('BLUDIT') or die('Bludit CMS.'); ?>` but to be honest: It doesn't look that good ;)