### PR TITLE
Update PHP-FPM config

### DIFF
--- a/pages/webservers/nginx/index.md
+++ b/pages/webservers/nginx/index.md
@@ -30,10 +30,11 @@ server {
 	}
 
 	location ~ \.php$ {
-		fastcgi_pass    unix:/run/php/php-fpm.sock;
-		fastcgi_index   index.php;
-		include         fastcgi.conf;
-	}
+		include fastcgi_params;
+		fastcgi_index index.php;
+		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+		fastcgi_pass unix:/var/run/php/php7.2-fpm.sock;
+        }
 
 	location / {
 		try_files $uri $uri/ /index.php?$args;
@@ -81,11 +82,11 @@ server {
 	}
 
 	location ~ \.php$ {
-		fastcgi_pass    unix:/var/run/php-fpm/php-fpm.sock;
-		fastcgi_index   index.php;
-		include         fastcgi.conf;
-		fastcgi_param   HTTPS on;
-	}
+		include fastcgi_params;
+		fastcgi_index index.php;
+		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+		fastcgi_pass unix:/var/run/php/php7.2-fpm.sock;
+    	}
 
 	location / {
 		try_files $uri $uri/ /index.php?$args;


### PR DESCRIPTION
Update config params to match Ubuntu 18.04 defaults (php7.2-fpm).

Otherwise, especially without `fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;`, a blank page will be served by the web server.