### PR TITLE
expand documentation on POST /api/pages attributes

### DIFF
--- a/pages/api/create-a-new-page/index.md
+++ b/pages/api/create-a-new-page/index.md
@@ -23,7 +23,7 @@ Bellow the list of parameters allowed for this endpoint.
 | content | `string` Page content. | |
 | tags | `string` Page tags. | |
 | type | `string` Page type. | |
-| date | `string` Page date. | |
+| date | `string` Page date (formatted as "YYYY-MM-DD Hours:Minutes:Seconds"). | |
 | dateModified | `string` Page modified date. | |
 | position | `string` Page position. | |
 | coverImage | `string` Page cover image. | |

--- a/pages/api/create-a-new-page/index.md
+++ b/pages/api/create-a-new-page/index.md
@@ -21,7 +21,7 @@ Bellow the list of parameters allowed for this endpoint.
 | `required` authentication | `string` Authentication token. | |
 | title | `string` Page title. | |
 | content | `string` Page content. | |
-| tags | `string` Page tags. | |
+| tags | `string` Page tags, separated by comma. | |
 | type | `string` Page type. | |
 | date | `string` Page date (formatted as "YYYY-MM-DD Hours:Minutes:Seconds"). | |
 | slug | `string` Page URL slug. | (Derived from lowercased title) |

--- a/pages/api/create-a-new-page/index.md
+++ b/pages/api/create-a-new-page/index.md
@@ -24,6 +24,7 @@ Bellow the list of parameters allowed for this endpoint.
 | tags | `string` Page tags. | |
 | type | `string` Page type. | |
 | date | `string` Page date (formatted as "YYYY-MM-DD Hours:Minutes:Seconds"). | |
+| slug | `string` Page URL slug. | (Derived from lowercased title) |
 | dateModified | `string` Page modified date. | |
 | position | `string` Page position. | |
 | coverImage | `string` Page cover image. | |


### PR DESCRIPTION
Had to experiment around to figure these out:

- date format is `"%Y-%m-%d %H:%M:%S"`
- you can override the `slug` attribute