### PR TITLE
fix spelling in dev- snippets tags: get current tag

### DIFF
--- a/pages/dev-snippets/tags/index.md
+++ b/pages/dev-snippets/tags/index.md
@@ -107,7 +107,7 @@ Alternative:
 	// Check if the user is browsing a tag
 	if ($WHERE_AM_I=='tag') {
 		// Get the tag key from the URL
-		$tagKey = $Url->slug();
+		$tagKey = $url->slug();
 
 		// Create the Tag-Object
 		$tag = new Tag($tagKey);


### PR DESCRIPTION
changed wrong spelling `$Url` to `$url` in the snippet "Get the active tag". 