### PR TITLE
Fix create new page API URL

### DIFF
--- a/pages/api/create-a-new-page/index.md
+++ b/pages/api/create-a-new-page/index.md
@@ -77,7 +77,7 @@ Execute the command and attach the `data.json` file:
 $ curl  -X POST \
 	-H "Content-Type: application/json" \
 	-d @data.json \
-	"https://www.example.com/api/pages/my-dog"
+	"https://www.example.com/api/pages"
 ```
 
 Response Body


### PR DESCRIPTION
The API URL in the example for creating a new page is wrong.