### PR TITLE
Typo in NGINX docs

### DIFF
--- a/pages/webservers/nginx/index.md
+++ b/pages/webservers/nginx/index.md
@@ -53,7 +53,7 @@ The server block uses the following configuration, and we added an extra block t
 ```
 
 server {
-    if ($host = example.coom) {
+    if ($host = example.com) {
         return 301 https://$host$request_uri;
 } # managed by Certbot
 


### PR DESCRIPTION
Nginx config can be at times confusing. Doesn't help users that a typo on the example url to be present.